### PR TITLE
feat(dev) Support query predicates for graph commit command

### DIFF
--- a/src/RedisGraph/Edge.php
+++ b/src/RedisGraph/Edge.php
@@ -6,20 +6,20 @@ namespace Redislabs\Module\RedisGraph;
 
 final class Edge
 {
-    private string $type;
+    private string $queryPredicate;
     private Node $sourceNode;
     private Node $destinationNode;
     private ?string $relation;
     private ?iterable $properties = [];
 
     public function __construct(
-        string $type,
+        string $queryPredicate,
         Node $sourceNode,
         ?string $relation,
         Node $destinationNode,
         ?iterable $properties = []
     ) {
-        $this->type = $type;
+        $this->queryPredicate = $queryPredicate;
         $this->sourceNode = $sourceNode;
         $this->destinationNode = $destinationNode;
         $this->relation = $relation;
@@ -44,12 +44,12 @@ final class Edge
 
     public function getType(): string
     {
-        return $this->type;
+        return $this->queryPredicate;
     }
 
     public function toString(): string
     {
-        if ($this->type === 'MERGE') {
+        if ($this->queryPredicate === 'MERGE') {
             return $this->toStringWithMerge();
         }
         return $this->toStringWithCreate();
@@ -104,5 +104,10 @@ final class Edge
             return quotedString((string) $propValue);
         }
         return (int) $propValue;
+    }
+
+    public function getQueryPredicate(): string
+    {
+        return $this->queryPredicate;
     }
 }

--- a/src/RedisGraph/GraphConstructor.php
+++ b/src/RedisGraph/GraphConstructor.php
@@ -9,7 +9,9 @@ use Redislabs\Module\RedisGraph\Interfaces\QueryInterface;
 class GraphConstructor
 {
     private string $name;
+    /** @var Node[]  */
     private array $nodes = [];
+    /** @var Edge[]  */
     private array $edges = [];
 
     public function __construct(string $name)
@@ -47,10 +49,10 @@ class GraphConstructor
     {
         $query = '';
         foreach ($this->nodes as $index => $node) {
-            $query .= 'MERGE ' . $node->toString() . ' ';
+            $query .= $node->getQueryPredicate() . ' ' . $node->toString() . ' ';
         }
         foreach ($this->edges as $index => $edge) {
-            $query .= 'MERGE ' . $edge->toString() . ' ';
+            $query .= $edge->getQueryPredicate() . ' ' . $edge->toString() . ' ';
         }
         return new Query($this->name, trim($query));
     }

--- a/src/RedisGraph/Node.php
+++ b/src/RedisGraph/Node.php
@@ -9,12 +9,14 @@ final class Node
     private ?string $label;
     private ?iterable $properties;
     private ?string $alias = null;
+    private ?string $queryPredicate;
 
-    public function __construct(?string $label = null, ?iterable $properties = null)
+    public function __construct(?string $label = null, ?iterable $properties = null, ?string $queryPredicate = null)
     {
         $this->label = $label;
         $this->alias = randomString();
         $this->properties = $properties;
+        $this->queryPredicate = $queryPredicate;
     }
 
     public static function create(): self
@@ -50,6 +52,13 @@ final class Node
     {
         $new = clone $this;
         $new->alias = $alias;
+        return $new;
+    }
+
+    public function withQueryPredicate(string $queryPredicate): self
+    {
+        $new = clone $this;
+        $new->queryPredicate = $queryPredicate;
         return $new;
     }
 
@@ -103,5 +112,10 @@ final class Node
             return quotedString((string) $propValue);
         }
         return (int) $propValue;
+    }
+
+    public function getQueryPredicate(): string
+    {
+        return $this->queryPredicate ?? 'MATCH';
     }
 }

--- a/tests/Module/GraphConstructorTest.php
+++ b/tests/Module/GraphConstructorTest.php
@@ -56,6 +56,40 @@ class GraphConstructorTest extends \Codeception\Test\Unit
         $propertiesDestination = ['name' => 'Japan'];
         $edgeProperties = ['purpose' => 'pleasure', 'duration' => 'two weeks'];
 
+        $person = Node::createWithLabel($labelSource)->withProperties($propertiesSource)->withAlias('CatOwner')
+            ->withQueryPredicate('MERGE');
+        $country = Node::createWithLabelAndProperties($labelDestination, $propertiesDestination)
+            ->withAlias('CatCountry')
+            ->withQueryPredicate('MERGE');
+
+        $edge = Edge::merge($person, 'visited', $country)->withProperties($edgeProperties);
+
+        $graph = new GraphConstructor('TRAVELLERS');
+        $graph->addNode($person);
+        $graph->addNode($country);
+        $graph->addEdge($edge);
+        $query = $graph->getCommitQueryWithMerge();
+        $this->assertEquals(
+            'MERGE (CatOwner:person {name: "John Doe", age: 33, gender: "male", status: "single"}) ' .
+            'MERGE (CatCountry:country {name: "Japan"}) ' .
+            'MERGE (CatOwner)-[:visited {purpose: "pleasure", duration: "two weeks"}]->(CatCountry)',
+            $query->getQueryString()
+        );
+        $this->assertEquals('TRAVELLERS', $query->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCreateQueryObjectWithMergeOnlyEdgesSuccessfully(): void
+    {
+        $labelSource =  'person';
+        $labelDestination =  'country';
+
+        $propertiesSource = ['name' => 'John Doe', 'age' => 33, 'gender' => 'male', 'status' => 'single'];
+        $propertiesDestination = ['name' => 'Japan'];
+        $edgeProperties = ['purpose' => 'pleasure', 'duration' => 'two weeks'];
+
         $person = Node::createWithLabel($labelSource)->withProperties($propertiesSource)->withAlias('CatOwner');
         $country = Node::createWithLabelAndProperties($labelDestination, $propertiesDestination)
             ->withAlias('CatCountry');
@@ -68,8 +102,8 @@ class GraphConstructorTest extends \Codeception\Test\Unit
         $graph->addEdge($edge);
         $query = $graph->getCommitQueryWithMerge();
         $this->assertEquals(
-            'MERGE (CatOwner:person {name: "John Doe", age: 33, gender: "male", status: "single"}) ' .
-            'MERGE (CatCountry:country {name: "Japan"}) ' .
+            'MATCH (CatOwner:person {name: "John Doe", age: 33, gender: "male", status: "single"}) ' .
+            'MATCH (CatCountry:country {name: "Japan"}) ' .
             'MERGE (CatOwner)-[:visited {purpose: "pleasure", duration: "two weeks"}]->(CatCountry)',
             $query->getQueryString()
         );


### PR DESCRIPTION
When creating a Node you can specify a predicate via withQueryPredicate()
or optional constructor parameter. When not specified the default predicate
is MATCH.

When creating an edge, you can use the Edge::create() or
Edge::merge() methods to determine the strategy.